### PR TITLE
Fixing issue with pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,10 @@ jobs:
           export PATH="$HOME/.gem/ruby/3.0.0/bin:$PATH"
 
       - name: Upload to Google Play (Internal Testing)
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
         run: |
-          echo "${{ secrets.SERVICE_ACCOUNT_JSON }}" | base64 --decode > /tmp/service_account.json
+          echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" > /tmp/service_account.json
           fastlane supply --apk app/build/outputs/apk/release/*.apk --track internal --json_key /tmp/service_account.json
 
 #     - name: Upload to Google Play (Production)


### PR DESCRIPTION
Removed the base64 decoding for the SERVICE_ACCOUNT_JSON secret, since the JSON key is now stored directly in the GitHub Secrets.